### PR TITLE
Add generic fetch-based API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,27 @@ To create a production build:
 ```bash
 npm run build
 ```
+
+## API client
+
+`src/api/client.ts` contains a small helper around `fetch` for talking to
+external APIs. It is written in TypeScript and can be used with any REST API.
+
+```ts
+import { ApiClient } from './src/api/client'
+
+const client = new ApiClient({ baseUrl: 'https://api.example.com' })
+
+interface User {
+  id: string
+  name: string
+}
+
+client.get<User>('/users/1').then(user => {
+  console.log(user.name)
+})
+```
+
+Use `post`, `put`, and `delete` for the other HTTP methods. The default export
+`apiClient` creates a client with no base URL, which can be used directly for
+simple requests.

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,70 @@
+export interface ApiClientOptions {
+  baseUrl?: string
+  headers?: Record<string, string>
+}
+
+export class ApiClient {
+  private baseUrl: string
+  private headers: Record<string, string>
+
+  constructor(options: ApiClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? ''
+    this.headers = options.headers ?? {}
+  }
+
+  private buildUrl(path: string): string {
+    return `${this.baseUrl}${path}`
+  }
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const url = this.buildUrl(path)
+    const response = await fetch(url, {
+      ...init,
+      headers: {
+        ...this.headers,
+        ...(init.headers || {})
+      }
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => '')
+      throw new Error(`Request failed with status ${response.status} ${errorText}`)
+    }
+
+    return response.status === 204 ? (undefined as T) : ((await response.json()) as T)
+  }
+
+  get<T>(path: string, init: RequestInit = {}) {
+    return this.request<T>(path, { ...init, method: 'GET' })
+  }
+
+  post<T>(path: string, body?: unknown, init: RequestInit = {}) {
+    return this.request<T>(path, {
+      ...init,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init.headers || {})
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined
+    })
+  }
+
+  put<T>(path: string, body?: unknown, init: RequestInit = {}) {
+    return this.request<T>(path, {
+      ...init,
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init.headers || {})
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined
+    })
+  }
+
+  delete<T>(path: string, init: RequestInit = {}) {
+    return this.request<T>(path, { ...init, method: 'DELETE' })
+  }
+}
+
+export const apiClient = new ApiClient()


### PR DESCRIPTION
## Summary
- add `ApiClient` wrapper using `fetch` for typed API calls
- document usage of API client in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68562cddecdc8329a62de5664c7a354e