### PR TITLE
Fix plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/react-dom": "^18.2.0",
     "typescript": "^5.4.0",
     "vite": "^5.1.0",
-    "@vitejs/plugin-react": "^5.0.0",
+    "@vitejs/plugin-react": "^4.2.0",
     "tailwindcss": "^4.0.0",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0"


### PR DESCRIPTION
## Summary
- correct @vitejs/plugin-react version in package.json

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68563ce107e0832984f863ef66df9012