### PR TITLE
Fix tailwind postcss plugin config

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "vite": "^5.1.0",
     "@vitejs/plugin-react": "^4.2.0",
     "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^0.1.0",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0"
   }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` instead of the `tailwindcss` package in PostCSS config
- add `@tailwindcss/postcss` dev dependency

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563dce5804832987da0d65cea582f7