### PR TITLE
Add auth slice and user login demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,31 @@ client.get<User>('/users/1').then(user => {
 Use `post`, `put`, and `delete` for the other HTTP methods. The default export
 `apiClient` creates a client with no base URL, which can be used directly for
 simple requests.
+
+## State Management
+
+Redux Toolkit manages the application's global state. Store setup and slices
+live under `src/store`. Typed hooks are provided for dispatching actions and
+selecting state:
+
+```ts
+import { useAppDispatch, useAppSelector } from './src/store/hooks'
+```
+
+The store is connected via the `Provider` component in `src/main.tsx`.
+
+### Authentication State
+
+`src/store/authSlice.ts` manages the currently authenticated user. Login and
+logout actions update the stored `user` and authentication `token`:
+
+```ts
+dispatch(login({ user, token }))
+dispatch(logout())
+```
+
+Use the typed selector to access the current user:
+
+```ts
+const user = useAppSelector(state => state.auth.user)
+```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.22.2"
+    "react-router-dom": "^6.22.2",
+    "@reduxjs/toolkit": "^1.9.5",
+    "react-redux": "^8.1.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,16 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import { BrowserRouter } from 'react-router-dom'
+import { Provider } from 'react-redux'
+import { store } from './store/store'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <Provider store={store}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </Provider>
   </React.StrictMode>,
 )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,7 +1,47 @@
+import { increment } from '../store/counterSlice'
+import { login, logout } from '../store/authSlice'
+import { useAppDispatch, useAppSelector } from '../store/hooks'
+
 function Home() {
+  const count = useAppSelector(state => state.counter.value)
+  const user = useAppSelector(state => state.auth.user)
+  const dispatch = useAppDispatch()
+
   return (
     <div className="p-4 text-center">
       <h1 className="text-3xl font-bold">Admin Dashboard Starter</h1>
+      <p className="mt-4">Count: {count}</p>
+      <button
+        className="mt-2 px-4 py-2 bg-blue-500 text-white rounded"
+        onClick={() => dispatch(increment())}
+      >
+        Increment
+      </button>
+      {user ? (
+        <div className="mt-4">
+          <p>Logged in as {user.name}</p>
+          <button
+            className="mt-2 px-4 py-2 bg-red-500 text-white rounded"
+            onClick={() => dispatch(logout())}
+          >
+            Logout
+          </button>
+        </div>
+      ) : (
+        <button
+          className="mt-4 px-4 py-2 bg-green-600 text-white rounded"
+          onClick={() =>
+            dispatch(
+              login({
+                user: { id: '1', name: 'Jane Doe', email: 'jane@example.com' },
+                token: 'example-token',
+              }),
+            )
+          }
+        >
+          Login
+        </button>
+      )}
     </div>
   )
 }

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import type { User } from '../types/User'
+
+interface AuthState {
+  user: User | null
+  token: string | null
+}
+
+const initialState: AuthState = {
+  user: null,
+  token: null,
+}
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    login(state, action: PayloadAction<{ user: User; token: string }>) {
+      state.user = action.payload.user
+      state.token = action.payload.token
+    },
+    logout(state) {
+      state.user = null
+      state.token = null
+    },
+  },
+})
+
+export const { login, logout } = authSlice.actions
+export default authSlice.reducer

--- a/src/store/counterSlice.ts
+++ b/src/store/counterSlice.ts
@@ -1,0 +1,28 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+interface CounterState {
+  value: number
+}
+
+const initialState: CounterState = {
+  value: 0,
+}
+
+const counterSlice = createSlice({
+  name: 'counter',
+  initialState,
+  reducers: {
+    increment(state) {
+      state.value += 1
+    },
+    decrement(state) {
+      state.value -= 1
+    },
+    set(state, action: PayloadAction<number>) {
+      state.value = action.payload
+    },
+  },
+})
+
+export const { increment, decrement, set } = counterSlice.actions
+export default counterSlice.reducer

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import type { RootState, AppDispatch } from './store'
+
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,13 @@
+import { configureStore } from '@reduxjs/toolkit'
+import counterReducer from './counterSlice'
+import authReducer from './authSlice'
+
+export const store = configureStore({
+  reducer: {
+    counter: counterReducer,
+    auth: authReducer,
+  },
+})
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: string
+  name: string
+  email: string
+}


### PR DESCRIPTION
## Summary
- create `User` type and new `authSlice` for login/logout
- register auth reducer in the store
- show authentication example on Home page
- document auth state in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563b87d9108329acd8009f8329ce93