### PR TITLE
Add axios API layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.1",
-    "react-router-dom": "^6.22.2"
+    "react-router-dom": "^6.22.2",
+    "axios": "^1.6.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,26 @@
+import axios from 'axios'
+import { store } from '../store/store'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE,
+  timeout: 10000,
+})
+
+api.interceptors.request.use(config => {
+  const token = store.getState().auth.token
+  if (token) {
+    config.headers = config.headers ?? {}
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
+})
+
+api.interceptors.response.use(
+  response => response,
+  error => {
+    console.error('API Error', error)
+    return Promise.reject(error)
+  }
+)
+
+export default api

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,18 @@
+import api from './api'
+import type { User } from '../types/User'
+
+export interface LoginPayload {
+  email: string
+  password: string
+}
+
+export interface LoginResponse {
+  user: User
+  token: string
+}
+
+export const authService = {
+  login(payload: LoginPayload): Promise<LoginResponse> {
+    return api.post<LoginResponse>('/auth/login', payload).then(res => res.data)
+  },
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,8 @@
+import api from './api'
+import type { User } from '../types/User'
+
+export const userService = {
+  getAll(): Promise<User[]> {
+    return api.get<User[]>('/users').then(res => res.data)
+  },
+}


### PR DESCRIPTION
## Summary
- install axios dependency in `package.json`
- add Axios client with auth and error interceptors
- add `userService` and `authService` wrappers

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685641e83e348329879d5446f469c876