### PR TITLE
Implement basic auth flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,9 @@ import Navbar from './components/Navbar'
 import Home from './pages/Home'
 import About from './pages/About'
 import NotFound from './pages/NotFound'
+import Login from './pages/Login'
+import Admin from './pages/Admin'
+import RequireAuth from './components/RequireAuth'
 
 function App() {
   return (
@@ -11,6 +14,8 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/about" element={<About />} />
+        <Route path="/admin" element={<RequireAuth role="admin"><Admin /></RequireAuth>} />
+        <Route path="/login" element={<Login />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </div>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,8 @@
 import { NavLink } from 'react-router-dom'
+import { useAppSelector } from '../store/hooks'
 
 function Navbar() {
+  const user = useAppSelector(state => state.auth.user)
   return (
     <nav className="bg-white shadow mb-6">
       <ul className="flex gap-4 p-4">
@@ -14,6 +16,20 @@ function Navbar() {
             About
           </NavLink>
         </li>
+        {user?.role === 'admin' && (
+          <li>
+            <NavLink to="/admin" className={({ isActive }) => isActive ? 'font-bold' : undefined}>
+              Admin
+            </NavLink>
+          </li>
+        )}
+        {!user && (
+          <li>
+            <NavLink to="/login" className={({ isActive }) => isActive ? 'font-bold' : undefined}>
+              Login
+            </NavLink>
+          </li>
+        )}
       </ul>
     </nav>
   )

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,17 @@
+import { Navigate } from 'react-router-dom'
+import { useAppSelector } from '../store/hooks'
+
+interface Props {
+  children: JSX.Element
+  role?: string
+}
+
+function RequireAuth({ children, role }: Props) {
+  const token = useAppSelector(state => state.auth.token)
+  const user = useAppSelector(state => state.auth.user)
+  if (!token) return <Navigate to="/login" replace />
+  if (role && user?.role !== role) return <Navigate to="/" replace />
+  return children
+}
+
+export default RequireAuth

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,0 +1,10 @@
+function Admin() {
+  return (
+    <div className="p-4 text-center">
+      <h1 className="text-2xl font-bold">Admin Area</h1>
+      <p>Only users with the admin role can see this.</p>
+    </div>
+  )
+}
+
+export default Admin

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { increment } from '../store/counterSlice'
-import { login, logout } from '../store/authSlice'
+import { logout } from '../store/authSlice'
 import { useAppDispatch, useAppSelector } from '../store/hooks'
+import { Link } from 'react-router-dom'
 
 function Home() {
   const count = useAppSelector(state => state.counter.value)
@@ -19,7 +20,7 @@ function Home() {
       </button>
       {user ? (
         <div className="mt-4">
-          <p>Logged in as {user.name}</p>
+          <p>Logged in as {user.name} ({user.role})</p>
           <button
             className="mt-2 px-4 py-2 bg-red-500 text-white rounded"
             onClick={() => dispatch(logout())}
@@ -28,19 +29,9 @@ function Home() {
           </button>
         </div>
       ) : (
-        <button
-          className="mt-4 px-4 py-2 bg-green-600 text-white rounded"
-          onClick={() =>
-            dispatch(
-              login({
-                user: { id: '1', name: 'Jane Doe', email: 'jane@example.com' },
-                token: 'example-token',
-              }),
-            )
-          }
-        >
-          Login
-        </button>
+        <p className="mt-4">
+          <Link className="text-blue-600 underline" to="/login">Login to get started</Link>
+        </p>
       )}
     </div>
   )

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAppDispatch } from '../store/hooks'
+import { login } from '../store/authSlice'
+import { authService } from '../services/authService'
+
+function Login() {
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      const data = await authService.login({ email, password })
+      dispatch(login(data))
+      navigate('/')
+    } catch (err) {
+      setError('Login failed')
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="p-4 max-w-sm mx-auto space-y-4">
+      <h1 className="text-2xl font-bold text-center">Login</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <div>
+        <label className="block mb-1">Email</label>
+        <input
+          type="email"
+          className="w-full border px-2 py-1"
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Password</label>
+        <input
+          type="password"
+          className="w-full border px-2 py-1"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+      </div>
+      <button className="w-full bg-blue-500 text-white py-2 rounded">Log In</button>
+    </form>
+  )
+}
+
+export default Login

--- a/src/store/authSlice.ts
+++ b/src/store/authSlice.ts
@@ -6,10 +6,17 @@ interface AuthState {
   token: string | null
 }
 
-const initialState: AuthState = {
-  user: null,
-  token: null,
+function loadAuth(): AuthState {
+  try {
+    const stored = localStorage.getItem('auth')
+    if (stored) {
+      return JSON.parse(stored) as AuthState
+    }
+  } catch {}
+  return { user: null, token: null }
 }
+
+const initialState: AuthState = loadAuth()
 
 const authSlice = createSlice({
   name: 'auth',
@@ -18,10 +25,12 @@ const authSlice = createSlice({
     login(state, action: PayloadAction<{ user: User; token: string }>) {
       state.user = action.payload.user
       state.token = action.payload.token
+      localStorage.setItem('auth', JSON.stringify(state))
     },
     logout(state) {
       state.user = null
       state.token = null
+      localStorage.removeItem('auth')
     },
   },
 })

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -2,4 +2,5 @@ export interface User {
   id: string
   name: string
   email: string
+  role: string
 }


### PR DESCRIPTION
## Summary
- add user roles to `User` interface
- persist authentication state in `authSlice`
- create `RequireAuth` component for protected routes
- add login and admin pages
- update navbar and home page for role-based UI
- wire up routes with authentication

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: network access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68564718dc188329bad5aeb52ea5a662